### PR TITLE
adding helper methods for creating one off validation errors.

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,258 @@
+pull_request_rules:
+
+  # ===============================================================================
+  # DEPENDABOT
+  # ===============================================================================
+
+  - name: Automatic Merge for Dependabot Minor Version Pull Requests
+    conditions:
+      - -draft
+      - author~=^dependabot(|-preview)\[bot\]$
+      - check-success='build (1.17.x, ubuntu-latest)'
+      - check-success='build (1.16.x, ubuntu-latest)'
+      - check-success='build (1.17.x, macos-latest)'
+      - check-success='build (1.16.x, macos-latest)'
+      - check-success='lint (1.17.x, ubuntu-latest)'
+      - check-success='lint (1.16.x, ubuntu-latest)'
+      - check-success='lint (1.17.x, macos-latest)'
+      - check-success='lint (1.16.x, macos-latest)'
+      - check-success='Analyze (go)'
+      - title~=^Bump [^\s]+ from ([\d]+)\..+ to \1\.
+    actions:
+      review:
+        type: APPROVE
+        message: Automatically approving dependabot pull request
+      merge:
+        method: squash
+      label:
+        add:
+          - update
+  - name: Alert on major version detection
+    conditions:
+      - author~=^dependabot(|-preview)\[bot\]$
+      - check-success='build (1.17.x, ubuntu-latest)'
+      - check-success='build (1.16.x, ubuntu-latest)'
+      - check-success='build (1.17.x, macos-latest)'
+      - check-success='build (1.16.x, macos-latest)'
+      - check-success='lint (1.17.x, ubuntu-latest)'
+      - check-success='lint (1.16.x, ubuntu-latest)'
+      - check-success='lint (1.17.x, macos-latest)'
+      - check-success='lint (1.16.x, macos-latest)'
+      - check-success='Analyze (go)'
+      - -title~=^Bump [^\s]+ from ([\d]+)\..+ to \1\.
+    actions:
+      comment:
+        message: "⚠️ @theflyingcodr: this is a major version bump and requires your attention"
+      label:
+        add:
+          - update
+      assign:
+        users: [ "theflyingcodr" ]
+
+  # ===============================================================================
+  # AUTOMATIC MERGE (APPROVALS)
+  # ===============================================================================
+
+  - name: Automatic Merge ⬇️ on Approval ✔
+    conditions:
+      - or:
+          - author=theflyingcodr
+          - "#approved-reviews-by>=1"
+      - check-success='build (1.17.x, ubuntu-latest)'
+      - check-success='build (1.16.x, ubuntu-latest)'
+      - check-success='build (1.17.x, macos-latest)'
+      - check-success='build (1.16.x, macos-latest)'
+      - check-success='lint (1.17.x, ubuntu-latest)'
+      - check-success='lint (1.16.x, ubuntu-latest)'
+      - check-success='lint (1.17.x, macos-latest)'
+      - check-success='lint (1.16.x, macos-latest)'
+      - check-success='Analyze (go)'
+      - label!=work-in-progress
+      - -draft
+    actions:
+      review:
+        type: APPROVE
+      merge:
+        method: squash
+      comment:
+        message: "Automatically merging this PR, LGTM! \n\n  ![Great Success](https://media.giphy.com/media/a0h7sAqON67nO/giphy.gif?cid=ecf05e47wywpzv7bclrv6muzureq5hk0u3rd8fradbqjng68&rid=giphy.gif&ct=g)"
+
+
+  # ===============================================================================
+  # AUTHOR
+  # ===============================================================================
+
+  - name: Auto-Assign Author
+    conditions:
+      - "#assignee=0"
+    actions:
+      assign:
+        add_users:
+          - "{{author}}"
+
+  # ===============================================================================
+  # ALERTS
+  # ===============================================================================
+
+  - name: Notify on merge
+    conditions:
+      - merged
+      - label=automerge
+    actions:
+      comment:
+        message: "✅ @{{author}}: **{{title}}** has been merged successfully."
+  - name: Alert on merge conflict
+    conditions:
+      - conflict
+      - label=automerge
+    actions:
+      comment:
+        message: "🆘 @{{author}}: `{{head}}` has conflicts with `{{base}}` that must be resolved."
+      label:
+        add:
+          - conflict
+  - name: Alert on tests failure for automerge
+    conditions:
+      - label=automerge
+      - status-failure=commit
+    actions:
+      comment:
+        message: "🆘 @{{author}}: unable to merge due to CI failure."
+
+  - name: remove conflict label if not needed
+    conditions:
+      - -conflict
+    actions:
+      label:
+        remove:
+          - conflict
+
+  # ===============================================================================
+  # LABELS
+  # ===============================================================================
+  # Automatically add labels when PRs match certain patterns
+  #
+  # NOTE:
+  # - single quotes for regex to avoid accidental escapes
+  # - Mergify leverages Python regular expressions to match rules.
+  #
+  # Semantic commit messages
+  # - chore:     updating grunt tasks etc.; no production code change
+  # - docs:      changes to the documentation
+  # - feat:      feature or story
+  # - enhancement: an improvement to an existing feature
+  # - feat:      new feature for the user, not a new feature for build script
+  # - fix:       bug fix for the user, not a fix to a build script
+  # - idea:      general idea or suggestion
+  # - test:      test related changes
+  # ===============================================================================
+
+  - name: Hotfix label
+    conditions:
+      - "head~=(?i)^hotfix" # if the PR branch starts with hotfix/
+    actions:
+      label:
+        add: ["hot-fix"]
+  - name: Bug / Fix label
+    conditions:
+      - "head~=(?i)^(bug)?fix" # if the PR branch starts with (bug)?fix/
+    actions:
+      label:
+        add: [ "bug" ]
+  - name: Documentation label
+    conditions:
+      - "head~=(?i)^docs" # if the PR branch starts with docs/
+    actions:
+      label:
+        add: [ "documentation" ]
+  - name: Feature label
+    conditions:
+      - "head~=(?i)^feat(ure)?" # if the PR branch starts with feat(ure)?/
+    actions:
+      label:
+        add: ["feature"]
+  - name: Enhancement label
+    conditions:
+      - "head~=(?i)^enhancement?" # if the PR branch starts with enhancement/
+    actions:
+      label:
+        add: ["enhancement"]
+  - name: Chore label
+    conditions:
+      - "head~=(?i)^chore" # if the PR branch starts with chore/
+    actions:
+      label:
+        add: ["chore"]
+  - name: Question label
+    conditions:
+      - "head~=(?i)^question" # if the PR branch starts with question/
+    actions:
+      label:
+        add: ["question"]
+  - name: Test label
+    conditions:
+      - "head~=(?i)^test" # if the PR branch starts with test/
+    actions:
+      label:
+        add: ["test"]
+  - name: Idea label
+    conditions:
+      - "head~=(?i)^idea" # if the PR branch starts with idea/
+    actions:
+      label:
+        add: ["idea"]
+
+  # ===============================================================================
+  # STALE BRANCHES
+  # ===============================================================================
+
+  - name: Close stale pull request
+    conditions:
+      - base=main
+      - -closed
+      - updated-at<21 days ago
+    actions:
+      close:
+        message: |
+          This pull request looks stale. Feel free to reopen it if you think it's a mistake.
+      label:
+        add: [ "stale" ]
+  # ===============================================================================
+  # BRANCHES
+  # ===============================================================================
+
+  - name: Delete head branch after merge
+    conditions:
+      - merged
+    actions:
+      delete_head_branch:
+
+  #- name: automatic update for PR marked as “Ready-to-Go“
+  #  conditions:
+  #    - -conflict # skip PRs with conflicts
+  #    - -draft # filter-out GH draft PRs
+  #    - label="Ready-to-Go"
+  #  actions:
+  #    update:
+
+  # ===============================================================================
+  # CONVENTION
+  # ===============================================================================
+  # https://www.conventionalcommits.org/en/v1.0.0/
+  # Premium feature only
+
+  #- name: Conventional Commit
+  #  conditions:
+  #    - "title~=^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\(.+\\))?:"
+  #  actions:
+  #    post_check:
+  #      title: |
+  #        {% if check_succeed %}
+  #        Title follows Conventional Commit
+  #        {% else %}
+  #        Title does not follow Conventional Commit
+  #        {% endif %}
+  #      summary: |
+  #        {% if not check_succeed %}
+  #        Your pull request title must follow [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/).
+  #        {% endif %}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go-version: [1.14.x,1.15.x,1.16.x]
+        go-version: [1.16.x, 1.17.x]
         os: [macos-latest, windows-latest, ubuntu-latest]
     name: lint
     runs-on: ${{ matrix.os }}
@@ -26,7 +26,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [ 1.12.x,1.13.x,1.14.x,1.15.x,1.16.x ]
+        go-version: [ 1.16.x, 1.17.x ]
         os: [ macos-latest, windows-latest, ubuntu-latest ]
     runs-on:  ${{ matrix.os }}
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -336,7 +336,7 @@ linters:
     - govet
     - gosec
     - bodyclose
-    - golint
+    - revive
     - unconvert
     - dupl
     - maligned

--- a/validator.go
+++ b/validator.go
@@ -118,3 +118,34 @@ func (e ErrValidation) Error() string {
 func (e ErrValidation) BadRequest() bool {
 	return true
 }
+
+// NewSingleError is a simple way of creating a one off error
+// rather than calling a validate function.
+//   test, err := thing()
+//   if err != nil{
+//	    // this error is froma. bad request, convert to a validation error
+//	    return validator.NewSingleError("myField", []string{"this went wrong"})
+//   }
+// This will then be classed as a validation error and handled how you desire.
+func NewSingleError(fieldName string, msg []string) error {
+	return ErrValidation{
+		fieldName: msg,
+	}.Err()
+}
+
+// NewFromError is a simple way of creating a one off error
+// rather than calling a validate function.
+//   test, err := thing()
+//   if err != nil{
+//	    // this error is froma. bad request, convert to a validation error
+//	    return validator.NewFromError("myField", err)
+//   }
+// This will then be classed as a validation error and handled how you desire.
+func NewFromError(fieldName string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return ErrValidation{
+		fieldName: []string{err.Error()},
+	}.Err()
+}

--- a/validator_test.go
+++ b/validator_test.go
@@ -1,0 +1,77 @@
+package validator
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func Test_NewSingleError(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+	tests := map[string]struct {
+		fieldName string
+		errors    []string
+	}{
+		"empty string should return error with empty string": {
+			fieldName: "test",
+			errors:    []string{},
+		}, "single string should return error with single string": {
+			fieldName: "test",
+			errors:    []string{"i failed"},
+		}, "multiple string should return error with multiple string": {
+			fieldName: "test",
+			errors:    []string{"i failed", "i failed because of another thing"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := NewSingleError(test.fieldName, test.errors)
+			var val ErrValidation
+			ok := errors.As(err, &val)
+			is = is.NewRelaxed(t)
+			is.True(ok)
+			is.Equal(val[test.fieldName], test.errors)
+		})
+	}
+}
+
+func Test_NewFromError(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+	tests := map[string]struct {
+		fieldName string
+		error     error
+		exp       ErrValidation
+	}{
+		"nil error string should return error with empty string": {
+			fieldName: "test",
+			error:     nil,
+			exp:       nil,
+		}, "error should be returned in validator": {
+			fieldName: "test",
+			error:     errors.New("I failed"),
+			exp: map[string][]string{
+				"test": {"I failed"},
+			},
+		}, "wrapped error should be returned in validator": {
+			fieldName: "test",
+			error:     fmt.Errorf("i wrap %w", errors.New("I failed")),
+			exp: map[string][]string{
+				"test": {"i wrap I failed"},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := NewFromError(test.fieldName, test.error)
+			//val, ok := err.(ErrValidation)
+			is = is.NewRelaxed(t)
+			is.Equal(test.exp, err)
+		})
+	}
+}


### PR DESCRIPTION

```go
// NewSingleError is a simple way of creating a one off error
// rather than calling a validate function.
//   test, err := thing()
//   if err != nil{
//	    // this error is froma. bad request, convert to a validation error
//	    return validator.NewSingleError("myField", []string{"this went wrong"})
//   }
// This will then be classed as a validation error and handled how you desire.
func NewSingleError(fieldName string, msg []string) error
```

```go
// NewFromError is a simple way of creating a one off error
// rather than calling a validate function.
//   test, err := thing()
//   if err != nil{
//	    // this error is froma. bad request, convert to a validation error
//	    return validator.NewFromError("myField", err)
//   }
// This will then be classed as a validation error and handled how you desire.
func NewFromError(fieldName string, err error) error
```