### PR TITLE
Enhancement: Generic `Any`

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -292,3 +292,10 @@ func Any[T comparable](val T, vv ...T) ValidationFunc {
 		return errors.New("value not found in allowed values")
 	}
 }
+
+// AnyString will check if the provided string is in a set of allowed values.
+//
+// Deprecated: use Any instead. Will be removed in a future release.
+func AnyString(val string, vv ...string) ValidationFunc {
+	return Any(val, vv...)
+}

--- a/functions.go
+++ b/functions.go
@@ -280,8 +280,8 @@ func Email(val string) ValidationFunc {
 	}
 }
 
-// AnyString will check if the provided string is in a set of allowed values.
-func AnyString(val string, vv ...string) ValidationFunc {
+// Any will check if the provided value is in a set of allowed values.
+func Any[T comparable](val T, vv ...T) ValidationFunc {
 	return func() error {
 		for _, v := range vv {
 			if val == v {

--- a/functions_test.go
+++ b/functions_test.go
@@ -374,6 +374,7 @@ func TestMatchBytes(t *testing.T) {
 		})
 	}
 }
+
 func TestEqualBool(t *testing.T) {
 	t.Parallel()
 	is := is.New(t)
@@ -969,7 +970,7 @@ func TestEmpty(t *testing.T) {
 	}
 }
 
-func TestAnyString(t *testing.T) {
+func TestAny(t *testing.T) {
 	t.Parallel()
 	is := is.New(t)
 	tt := map[string]struct {
@@ -1000,7 +1001,7 @@ func TestAnyString(t *testing.T) {
 	for name, test := range tt {
 		t.Run(name, func(t *testing.T) {
 			is = is.NewRelaxed(t)
-			is.Equal(test.expErr, AnyString(test.val, test.list...)())
+			is.Equal(test.expErr, Any(test.val, test.list...)())
 		})
 	}
 }


### PR DESCRIPTION
Add an `Any` function that accepts `comparable`, so we can run `Any` on integers, and custom string types.