### PR TITLE
Fix whitespace validation to comply with Go docs and older release

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -181,6 +181,8 @@ func NotEmpty(v interface{}) ValidationFunc {
 		switch val.Kind() {
 		case reflect.Map, reflect.Slice:
 			valid = val.Len() > 0 && !val.IsNil()
+		case reflect.String:
+			valid = len(strings.TrimSpace(val.String())) > 0
 		default:
 			valid = !val.IsZero()
 		}

--- a/functions_test.go
+++ b/functions_test.go
@@ -709,6 +709,10 @@ func TestNotEmpty(t *testing.T) {
 			val:    "",
 			expErr: errors.New(validateEmpty),
 		},
+		"whitespace string": {
+			val:    "    ",
+			expErr: errors.New(validateEmpty),
+		},
 		"non-empty time": {
 			val: time.Now(),
 		},
@@ -847,6 +851,12 @@ func TestEmpty(t *testing.T) {
 		},
 		"empty string": {
 			val: "",
+		},
+		"whitespace string": {
+			val: "   	",
+		},
+		"complex whitespace string": {
+			val: "   	\t\t\n   \u00a0 \u2003 \u2009",
 		},
 		"non-empty time": {
 			val:    time.Now(),


### PR DESCRIPTION
👋 Hey!

Whitespace is not validated according to the Go doc at

https://github.com/theflyingcodr/govalidator/blob/27caec56bc0b251a9a465f8d9c0b5b7e0219904f/functions.go#L197 and
https://github.com/theflyingcodr/govalidator/blob/27caec56bc0b251a9a465f8d9c0b5b7e0219904f/functions.go#L170

Regression bug between
[`v0.0.2...v0.1.3`#diff-5faaf3bff8](https://github.com/theflyingcodr/govalidator/compare/v0.0.2...v0.1.3#diff-5faaf3bff8320883fedc2b5e1828c8cea82467bd7d8357e1c824dafe50835bfbL255-L256) (lines 255-256)

Specifically in commit: https://github.com/theflyingcodr/govalidator/commit/00804888e5fb15540838632bb6d565b6b310919e#diff-5faaf3bff8320883fedc2b5e1828c8cea82467bd7d8357e1c824dafe50835bfbL257-L258

Either 
* Go docs should be adjusted and breaking change documented or 
* whitespaces should be handled as previously, as described in go docs and implemented in this PR